### PR TITLE
Added js variable name and json integer data type check

### DIFF
--- a/src/Highcharts.php
+++ b/src/Highcharts.php
@@ -84,6 +84,7 @@ class Highcharts extends Widget
 {
     protected $constr = 'Chart';
     protected $baseScript = 'highcharts';
+    public $varName = 'chart';
     public $options = [];
     public $htmlOptions = [];
     public $setupOptions = [];
@@ -131,7 +132,7 @@ class Highcharts extends Widget
         // prepare and register JavaScript code block
         $jsOptions = Json::encode($this->options, JSON_NUMERIC_CHECK);
         $setupOptions = Json::encode($this->setupOptions);
-        $js = "Highcharts.setOptions($setupOptions); var chart = new Highcharts.{$this->constr}($jsOptions);";
+        $js = "Highcharts.setOptions($setupOptions); var {$this->varName} = new Highcharts.{$this->constr}($jsOptions);";
         $key = __CLASS__ . '#' . $this->id;
         if (is_string($this->callback)) {
             $callbackScript = "function {$this->callback}(data) {{$js}}";

--- a/src/Highcharts.php
+++ b/src/Highcharts.php
@@ -129,7 +129,7 @@ class Highcharts extends Widget
         HighchartsAsset::register($this->view)->withScripts($this->scripts);
 
         // prepare and register JavaScript code block
-        $jsOptions = Json::encode($this->options);
+        $jsOptions = Json::encode($this->options, JSON_NUMERIC_CHECK);
         $setupOptions = Json::encode($this->setupOptions);
         $js = "Highcharts.setOptions($setupOptions); var chart = new Highcharts.{$this->constr}($jsOptions);";
         $key = __CLASS__ . '#' . $this->id;


### PR DESCRIPTION
Added json encode options for checking integer data type.

Added varName param. Variable name is needed in case when there is possibility to use more than one chart in page and it is planned to call these charts (modify their data) from js.