### PR TITLE
Allow returning JS objects in addition to arrays from series data helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # netbeans project files
 nbproject
+
+vendor

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/SeriesDataHelper.php
+++ b/src/SeriesDataHelper.php
@@ -177,8 +177,8 @@ class SeriesDataHelper extends Component implements JsonSerializable
         $data = [];
         foreach ($this->data->models as $model) {
             $row = [];
-            foreach ($this->columns as $column) {
-                $row[] = call_user_func($column[1], $model[$column[0]]);
+            foreach ($this->columns as $index => $column) {
+                $row[$index] = call_user_func($column[1], $model[$column[0]]);
             }
 
             $data[] = $row;

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace miloschumanunit\highcharts;
+
+use yii\helpers\ArrayHelper;
+
+/**
+ * This is the base class for all yii framework unit tests.
+ */
+abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+{
+    public static $params;
+
+    /**
+     * Clean up after test.
+     * By default the application created with [[mockApplication]] will be destroyed.
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->destroyApplication();
+    }
+
+    /**
+     * Returns a test configuration param from /data/config.php
+     * @param  string $name params name
+     * @param  mixed $default default value to use when param is not set.
+     * @return mixed  the value of the configuration param
+     */
+    public static function getParam($name, $default = null)
+    {
+        if (static::$params === null) {
+            static::$params = require(__DIR__ . '/data/config.php');
+        }
+
+        return isset(static::$params[$name]) ? static::$params[$name] : $default;
+    }
+
+    /**
+     * Populates Yii::$app with a new application
+     * The application will be destroyed on tearDown() automatically.
+     * @param array $config The application configuration, if needed
+     * @param string $appClass name of the application class to create
+     */
+    protected function mockApplication($config = [], $appClass = '\yii\console\Application')
+    {
+        new $appClass(ArrayHelper::merge([
+            'id' => 'testapp',
+            'basePath' => __DIR__,
+            'vendorPath' => $this->getVendorPath(),
+        ], $config));
+    }
+
+    protected function mockWebApplication($config = [], $appClass = '\yii\web\Application')
+    {
+        new $appClass(ArrayHelper::merge([
+            'id' => 'testapp',
+            'basePath' => __DIR__,
+            'vendorPath' => $this->getVendorPath(),
+            'components' => [
+                'request' => [
+                    'cookieValidationKey' => 'wefJDF8sfdsfSDefwqdxj9oq',
+                    'scriptFile' => __DIR__ .'/index.php',
+                    'scriptUrl' => '/index.php',
+                ],
+            ]
+        ], $config));
+    }
+
+    protected function getVendorPath()
+    {
+        $vendor = dirname(dirname(__DIR__)) . '/vendor';
+        if (!is_dir($vendor)) {
+            $vendor = dirname(dirname(dirname(dirname(__DIR__))));
+        }
+        return $vendor;
+    }
+
+    /**
+     * Destroys application in Yii::$app by setting it to null.
+     */
+    protected function destroyApplication()
+    {
+        if (\Yii::$app && \Yii::$app->has('session', true)) {
+            \Yii::$app->session->close();
+        }
+        \Yii::$app = null;
+    }
+
+    /**
+     * Asserting two strings equality ignoring line endings
+     *
+     * @param string $expected
+     * @param string $actual
+     */
+    public function assertEqualsWithoutLE($expected, $actual)
+    {
+        $expected = str_replace("\r\n", "\n", $expected);
+        $actual = str_replace("\r\n", "\n", $actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/SeriesDataHelperTest.php
+++ b/tests/SeriesDataHelperTest.php
@@ -39,6 +39,41 @@ class SeriesDataHelperTest extends BaseTestCase
         $this->assertEquals( 4, $results[1][1] );
     }
 
+    /**
+     * test fancy data processing to produce JS objects instead of arrays
+     */
+    public function testFancyDataProcessing()
+    {
+        $data = [
+            [
+                'date_measured' => '2016-03-01 03:00:00',
+                'open'          => 3.14,
+                'pointData'     => 'Show this on the graph',
+            ],
+            [
+                'date_measured' => '2016-03-02 03:00:00',
+                'open'          => 4.14,
+                'pointData'     => 'This as well',
+            ]
+        ];
+        $columns      = [
+            'x' => [ 'date_measured', 'datetime' ],
+            'y' => 'open:int',
+            'extra' => 'pointData:raw',
+        ];
+
+        $dataProvider = $this->setupDataProvider($data);
+
+        $helper  = new SeriesDataHelper( $dataProvider, $columns );
+        $results = $helper->jsonSerialize();
+        $this->assertEquals( strtotime('2016-03-01 03:00:00') * 1000, $results[0]['x']);
+        $this->assertEquals( 3, $results[0]['y'] );
+        $this->assertEquals( 'Show this on the graph', $results[0]['extra'] );
+        $this->assertEquals( strtotime('2016-03-02 03:00:00') * 1000, $results[1]['x'] );
+        $this->assertEquals( 4, $results[1]['y'] );
+        $this->assertEquals( 'This as well', $results[1]['extra'] );
+    }
+
     private function setupDataProvider($data)
     {
         return new ArrayDataProvider( [

--- a/tests/SeriesDataHelperTest.php
+++ b/tests/SeriesDataHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace miloschumanunit\highcharts;
+
+use miloschuman\highcharts\SeriesDataHelper;
+use yii\data\ArrayDataProvider;
+
+/**
+ * SeriesDataHelperTest.php
+ */
+class SeriesDataHelperTest extends BaseTestCase
+{
+    /**
+     * test basic data processing using current setup
+     */
+    public function testBasicProcessing()
+    {
+        $data = [
+            [
+                'date_measured' => '2016-03-01 03:00:00',
+                'open'          => 3.14,
+            ],
+            [
+                'date_measured' => '2016-03-02 03:00:00',
+                'open'          => 4.14,
+            ]
+        ];
+        $columns      = [
+            [ 'date_measured', 'datetime' ],
+            'open:int',
+        ];
+
+        $dataProvider = $this->setupDataProvider($data);
+
+        $helper  = new SeriesDataHelper( $dataProvider, $columns );
+        $results = $helper->process();
+        $this->assertEquals( strtotime('2016-03-01 03:00:00') * 1000, $results[0][0] );
+        $this->assertEquals( 3, $results[0][1] );
+        $this->assertEquals( strtotime('2016-03-02 03:00:00') * 1000, $results[1][0] );
+        $this->assertEquals( 4, $results[1][1] );
+    }
+
+    private function setupDataProvider($data)
+    {
+        return new ArrayDataProvider( [
+            'allModels' => $data,
+            'sort' => false,
+            'pagination' => false,
+        ] );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+// ensure we get report on all possible php errors
+error_reporting(-1);
+
+define('YII_ENABLE_ERROR_HANDLER', false);
+define('YII_DEBUG', true);
+$_SERVER['SCRIPT_NAME'] = '/' . __DIR__;
+$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+require_once(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
+
+Yii::setAlias('@miloschumanunit/highcharts', __DIR__);
+
+date_default_timezone_set('UTC');


### PR DESCRIPTION
In a system I used your extension for with Yii1, we needed the ability to pass additional data to the chart to be used in tooltips.  This PR adds the ability to generate JS objects in addition to JS arrays (and I wrote some tests to ensure that that works as intended).

More details on this can be seen here:
http://api.highcharts.com/highcharts#series<area>.data

and here:
http://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/highcharts/series/data-array-of-objects/

Thoughts?  I wonder about hooking your repo up to Travis as well so we can start having tests run as part of PRs ...