### PR TITLE
Fix temporarily suppress notice on PHP82

### DIFF
--- a/src/SeriesDataHelper.php
+++ b/src/SeriesDataHelper.php
@@ -147,6 +147,7 @@ class SeriesDataHelper extends Component implements JsonSerializable
     /**
      * @inheritdoc
      */
+     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->process();


### PR DESCRIPTION
@miloschuman, Function `jsonSerialize()` must be mixed type on PHP82.

Full error:
> During inheritance of JsonSerializable: Uncaught yii\base\ErrorException: Return type of miloschuman\highcharts\SeriesDataHelper::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to 